### PR TITLE
json_hal_walker: use url.resolve to correctly construct links

### DIFF
--- a/lib/json_hal_walker.js
+++ b/lib/json_hal_walker.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var url = require('url')
 var halfred = require('halfred')
 var minilog = require('minilog')
 var _s = require('underscore.string')
@@ -185,11 +186,7 @@ function findEmbeddedWithoutIndex(resourceArray, key) {
 
 JsonHalWalker.prototype.postProcessStep = function(nextStep) {
   if (nextStep.uri) {
-    if (_s.endsWith(this.startUri, '/') &&
-        _s.startsWith(nextStep.uri, '/')) {
-      nextStep.uri = _s.splice(nextStep.uri, 0, 1)
-    }
-    nextStep.uri = this.startUri + nextStep.uri
+    nextStep.uri = url.resolve(this.startUri, nextStep.uri)
   }
 }
 


### PR DESCRIPTION
fixes cases where the entry point has a pathname other than `/`.
