### PR TITLE
Adding a logic to deal with case where body comes as arg but not in response

### DIFF
--- a/lib/walker.js
+++ b/lib/walker.js
@@ -120,7 +120,10 @@ Walker.prototype.process = function(step, callback) {
 
 Walker.prototype.get = function(step, callback) {
   log.debug('request to ' + step.uri);
-  this.request.get(step.uri, function(err, response) {
+  this.request.get(step.uri, function(err, response, body) {
+    if (body && !response.body) {
+      response.body = body;
+    }
     log.debug('request.get returned');
     if (err) { return callback(err, step); }
     log.debug('request to ' + step.uri + ' finished (' + response.statusCode +

--- a/test/json_requests.js
+++ b/test/json_requests.js
@@ -59,9 +59,9 @@ describe('The JSON client\'s', function() {
     callback = sinon.spy();
 
     get.withArgs(rootUri, sinon.match.func).callsArgWithAsync(
-        1, null, rootResponse);
+        1, null, rootResponse, rootResponse.body);
     get.withArgs(getUri, sinon.match.func).callsArgWithAsync(1, null,
-        result);
+        result, result.body);
     get.withArgs(postUri, sinon.match.func).callsArgWithAsync(1,
         new Error('GET is not implemented for this URI, please POST ' +
         'something'));


### PR DESCRIPTION
We ran into a strange issue where the body doesn't come through in the response argument, but does come through in the third body argument of the request. 

I'm not 100% sure as to why this happens (if you could shed some light on it that would be useful), but the following logic fixes the problem.
