### PR TITLE
supporting URIs that are url encoded by decoding the URI before checking...

### DIFF
--- a/lib/walker.js
+++ b/lib/walker.js
@@ -227,6 +227,8 @@ Walker.prototype.resolveJSONPath = function(link, doc) {
 
 Walker.prototype.resolveUriTemplate = function(uri, templateParams,
     templateIndex) {
+  var decodedUri = decodeURIComponent(uri);
+
   if (util.isArray(templateParams)) {
     // if template params were given as an array, only use the array element
     // for the current index for URI template resolving.
@@ -237,11 +239,11 @@ Walker.prototype.resolveUriTemplate = function(uri, templateParams,
     templateParams = {};
   }
 
-  if (_s.contains(uri, '{')) {
-    var template = uriTemplate.parse(uri);
+  if (_s.contains(decodedUri, '{')) {
+    var template = uriTemplate.parse(decodedUri);
     return template.expand(templateParams);
   } else {
-    return uri;
+    return decodedUri;
   }
 };
 


### PR DESCRIPTION
... for curly braces

Hi,

I'm using Hapi.js (node web server) with the halacious plugin.  I noticed that the hapi server would return the curly braces in the HAL _links as url encoded.  This causes the conditional check in traverson's Walker.prototype.resolveUriTemplate to not work, since it's just looking for the '{' character instead of the url encoded '%7b'.

I simply am decoding the URI before checking for curly braces.  I'm wondering if this should be done elsewhere.

But it works for my use case and the tests are passing.
