### PR TITLE
Update user-guide.markdown

### DIFF
--- a/user-guide.markdown
+++ b/user-guide.markdown
@@ -134,7 +134,7 @@ Because the list of link relations given to `follow` is exhausted now (`resource
 
 ```
 We have followed the path and reached the target resource.
-{ "the_document": "that we really wanted to have", "with": "lots of interesting and valuable content", ...  }
+{ "the_resource": "that we really wanted to have", "with": "lots of interesting and valuable content", ...  }
 ```
 
 ### Configuring Traverson &mdash; the Request Builder Object


### PR DESCRIPTION
Fix the inconsistent example output.
In the examples, should all the 'the_document' be changed to 'the_resource' to match the API naming such as method name 'getResource'.