### PR TITLE
non breaking space results in edge case error

### DIFF
--- a/lib/transforms/get_options_for_step.js
+++ b/lib/transforms/get_options_for_step.js
@@ -20,7 +20,7 @@ module.exports = function getOptionsForStep(t) {
 function addAutoHeaders(t, options) {
   var autoHeaderValue =
     // we accept a static mediaType property as well as an instance property
-    t.adapter.constructor.mediaType || 
+    t.adapter.constructor.mediaType ||
     t.adapter.mediaType;
 
   // The content negotiation adapter does not (and can not) provide a value


### PR DESCRIPTION
Hello,

I just came across this edge case error with [line 23 in get_options_for_step.js](https://github.com/traverson/traverson/blob/master/lib/transforms/get_options_for_step.js#L23). 

Behind the two pipes there is an non breaking space. When using traverson though browserify in a html page without utf-8 character encoding this results in an exception. The lines in the browserify build will be:

```js
t.adapter.constructor.mediaType ||Â 
t.adapter.mediaType;
```

Obviously, the Â will cause the error. I'm making this PR since it seemd like an easy fix. Should not break anything else ;-)

Thanks for your awesome work on Traverson,

Simon