### PR TITLE
update to the latest request

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "jsonpath-plus": "^0.16.0",
     "minilog": "^3.1.0",
-    "request": "^2.83.0",
+    "request": "^2.87.0",
     "resolve-url": "^0.2.1",
     "superagent": "^3.8.1",
     "underscore.string": "^3.3.4",


### PR DESCRIPTION
to remove the dependency on hawk, which in-turn depended on a vulnerable version of hoek: https://nodesecurity.io/advisories/566