### PR TITLE
fix(http): fix error message for convertResponseToObject case

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -20,7 +20,8 @@ var checkHttpStatus = require('./transforms/check_http_status')
   , extractUrl =  require('./transforms/extract_url')
   , fetchLastResource =  require('./transforms/fetch_last_resource')
   , executeLastHttpRequest = require('./transforms/execute_last_http_request')
-  , executeHttpRequest = require('./transforms/execute_http_request')
+  , executeLastHttpRequestForConvertResponse =
+      require('./transforms/execute_last_http_request_for_convert_response')
   , parse = require('./transforms/parse')
   , parseLinkHeader = require('./transforms/parse_link_header');
 
@@ -28,6 +29,7 @@ var checkHttpStatus = require('./transforms/check_http_status')
  * Starts the link traversal process and end it with an HTTP get.
  */
 exports.get = function(t, callback) {
+  t.lastMethodName = 'GET';
   var transformsAfterLastStep;
   if (t.convertResponseToObject) {
     transformsAfterLastStep = [
@@ -65,6 +67,7 @@ exports.getUrl = function(t, callback) {
  * the callback.
  */
 exports.post = function(t, callback) {
+  t.lastMethodName = 'POST';
   walkAndExecute(t,
       t.requestModuleInstance,
       t.requestModuleInstance.post,
@@ -78,6 +81,7 @@ exports.post = function(t, callback) {
  * the callback.
  */
 exports.put = function(t, callback) {
+  t.lastMethodName = 'PUT';
   walkAndExecute(t,
       t.requestModuleInstance,
       t.requestModuleInstance.put,
@@ -91,6 +95,7 @@ exports.put = function(t, callback) {
  * the callback.
  */
 exports.patch = function(t, callback) {
+  t.lastMethodName = 'PATCH';
   walkAndExecute(t,
       t.requestModuleInstance,
       t.requestModuleInstance.patch,
@@ -103,6 +108,7 @@ exports.patch = function(t, callback) {
  * last URL. Passes the HTTP response of the DELETE request to the callback.
  */
 exports.delete = function(t, callback) {
+  t.lastMethodName = 'DELETE';
   walkAndExecute(t,
       t.requestModuleInstance,
       t.requestModuleInstance.del,
@@ -114,7 +120,7 @@ function walkAndExecute(t, request, method, callback) {
   var transformsAfterLastStep;
   if (t.convertResponseToObject) {
     transformsAfterLastStep = [
-      executeHttpRequest,
+      executeLastHttpRequestForConvertResponse,
       checkHttpStatus,
       parse,
       parseLinkHeader,

--- a/lib/http_requests.js
+++ b/lib/http_requests.js
@@ -21,7 +21,7 @@ var nextTickAvailable = process &&
 exports.fetchResource = function fetchResource(t, callback) {
   log.debug('fetching resource for next step');
   if (t.step.url) {
-    log.debug('fetching resource from ', t.step.url);
+    log.debug('fetching resource from', t.step.url);
     return executeHttpGet(t, callback);
   } else if (t.step.doc) {
     // The step already has an attached result document, so all is fine and we
@@ -50,12 +50,13 @@ exports.fetchResource = function fetchResource(t, callback) {
 
 function executeHttpGet(t, callback) {
   var options = getOptionsForStep(t);
-  log.debug('HTTP GET request to ', t.step.url);
-  log.debug('options ', options);
+  log.debug('HTTP GET request to', t.step.url);
+  log.debug('options', options);
+  t.mostRecentHttpMethodName = 'GET';
   t.currentRequest =
     t.requestModuleInstance.get(t.step.url, options,
         function(err, response, body) {
-    log.debug('HTTP GET request to ' + t.step.url + ' returned');
+    log.debug('HTTP GET request to', t.step.url, 'returned');
     t.currentRequest = null;
 
     // workaround for cases where response body is empty but body comes in as
@@ -68,8 +69,8 @@ function executeHttpGet(t, callback) {
     if (err) {
      return callback(err, t);
     }
-    log.debug('request to ' + t.step.url + ' finished without error (' +
-      response.statusCode + ')');
+    log.debug('request to', t.step.url, 'finished without error (',
+      response.statusCode, ')');
 
     if (!detectContentType(t, callback)) return;
 
@@ -84,20 +85,21 @@ function executeHttpGet(t, callback) {
 // This method is currently used for POST/PUT/PATCH/DELETE at the end of a link
 // traversal process. If the link traversal process requires a GET as the last
 // request, Traverson uses exectueHttpGet.
-exports.executeHttpRequest = function(t, request, method, callback) {
+exports.executeHttpRequest =
+    function(t, request, method, methodName, callback) {
   var requestOptions = getOptionsForStep(t);
   if (t.body !== null && typeof t.body !== 'undefined') {
     requestOptions.body = (t.rawPayload || requestOptions.jsonReplacer) ?
       t.body : JSON.stringify(t.body);
   }
 
-  log.debug('HTTP ' + method.name + ' request to ', t.step.url);
-  log.debug('options ', requestOptions);
+  log.debug('HTTP', methodName, 'request to', t.step.url);
+  log.debug('options', requestOptions);
+  t.mostRecentHttpMethodName = methodName;
   t.currentRequest =
     method.call(request, t.step.url, requestOptions,
         function(err, response, body) {
-    log.debug('HTTP ' + method.name + ' request to ' + t.step.url +
-      ' returned');
+    log.debug('HTTP', methodName, 'request to', t.step.url, 'returned');
     t.currentRequest = null;
 
     // workaround for cases where response body is empty but body comes in as

--- a/lib/json_adapter.js
+++ b/lib/json_adapter.js
@@ -41,7 +41,7 @@ JsonAdapter.prototype.findNextStep = function(t, link) {
 
 JsonAdapter.prototype._handleLinkRel = function(doc, link) {
   var linkRel = link.value;
-  this.log.debug('looking for link-rel in doc', linkRel, doc);
+  this.log.debug('looking for link-rel', linkRel, 'in doc', doc);
   var url;
   if (this._testJSONPath(linkRel)) {
     return { url: this._resolveJSONPath(doc, linkRel) };

--- a/lib/transforms/check_http_status.js
+++ b/lib/transforms/check_http_status.js
@@ -29,7 +29,7 @@ module.exports = function checkHttpStatus(t) {
   // condition. 1xx should not occur.
   var httpStatus = t.step.response.statusCode;
   if (httpStatus && (httpStatus < 200 || httpStatus >= 300)) {
-    var error = httpError(t.step.url, httpStatus, t.step.response.body);
+    var error = httpError(t, httpStatus);
     log.error('unexpected http status code');
     log.error(error);
     t.callback(error);
@@ -39,11 +39,14 @@ module.exports = function checkHttpStatus(t) {
   return true;
 };
 
-function httpError(url, httpStatus, body) {
-  var error = createError('HTTP GET for ' + url +
-      ' resulted in HTTP status code ' + httpStatus + '.', errors.HTTPError);
-  error.url = url;
+function httpError(t, httpStatus) {
+  var error =
+    createError('HTTP ' + t.mostRecentHttpMethodName + ' request to ' +
+      t.step.url + ' resulted in HTTP status code ' + httpStatus + '.',
+      errors.HTTPError);
+  error.url = t.step.url;
   error.httpStatus = httpStatus;
+  var body = t.step.response.body;
   error.body = body;
   try {
     error.doc = JSON.parse(body);

--- a/lib/transforms/execute_last_http_request.js
+++ b/lib/transforms/execute_last_http_request.js
@@ -7,7 +7,7 @@ var minilog = require('minilog')
 
 /*
  * Execute the last http request in a traversal that ends in
- * post/put/patch/delete.
+ * post/put/patch/delete and call t.callback immediately when done.
  */
 // TODO Why is this different from when do a GET at the end of the traversal?
 // Probably only because the HTTP method is configurable here (with
@@ -19,7 +19,12 @@ function executeLastHttpRequest(t, callback) {
     return abortTraversal.callCallbackOnAbort(t);
   }
   httpRequests.executeHttpRequest(
-      t, t.requestModuleInstance, t.lastMethod, t.callback);
+      t,
+      t.requestModuleInstance,
+      t.lastMethod,
+      t.lastMethodName,
+      t.callback
+  );
 }
 
 executeLastHttpRequest.isAsync = true;

--- a/lib/transforms/execute_last_http_request_for_convert_response.js
+++ b/lib/transforms/execute_last_http_request_for_convert_response.js
@@ -15,19 +15,25 @@ var minilog = require('minilog')
 // Probably only because the HTTP method is configurable here (with
 // t.lastMethod), we might be able to unify this with the
 // fetch_resource/fetch_last_resource transform.
-function executeLastHttpRequest(t, callback) {
+function executeLastHttpRequestForConvertResponse(t, callback) {
   // always check for aborted before doing an HTTP request
   if (t.aborted) {
     return abortTraversal.callCallbackOnAbort(t);
   }
-  // only diff to execute_last_http_request: pass a new callback function
-  // instead of t.callback.
+  // The only diff to the execute_last_http_request transform: pass a new
+  // callback function instead of calling t.callback immediately. This enables
+  // other transforms to run after the HTTP request (check status code, convert
+  // response to object, ...)
   httpRequests.executeHttpRequest(
-      t, t.requestModuleInstance, t.lastMethod, function(err, response) {
+      t,
+      t.requestModuleInstance,
+      t.lastMethod,
+      t.lastMethodName,
+      function(err, response) {
     if (err) {
       if (!err.aborted) {
         log.debug('error while executing http request, ' +
-                  'processing step ', t.step);
+                  'processing step', t.step);
         log.error(err);
       }
       return t.callback(err);
@@ -36,6 +42,6 @@ function executeLastHttpRequest(t, callback) {
   });
 }
 
-executeLastHttpRequest.isAsync = true;
+executeLastHttpRequestForConvertResponse.isAsync = true;
 
-module.exports = executeLastHttpRequest;
+module.exports = executeLastHttpRequestForConvertResponse;

--- a/lib/transforms/resolve_uri_template.js
+++ b/lib/transforms/resolve_uri_template.js
@@ -21,7 +21,7 @@ module.exports = function resolveUriTemplate(t) {
       log.debug('resolving URI template');
       var template = uriTemplate.parse(t.step.url);
       var resolved = template.expand(templateParams);
-      log.debug('resolved to ', resolved);
+      log.debug('resolved to', resolved);
       t.step.url = resolved;
     }
   }

--- a/lib/transforms/switch_to_next_step.js
+++ b/lib/transforms/switch_to_next_step.js
@@ -6,7 +6,7 @@ var minilog = require('minilog')
 module.exports = function switchToNextStep(t) {
   // extract next link to follow from last response
   var link = t.links[t.step.index];
-  log.debug('next link: ' + link);
+  log.debug('next link:', link);
 
   // save last step before overwriting it with the next step (required for
   // relative URL resolution, where we need the last URL)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6591,9 +6591,9 @@
       "dev": true
     },
     "traverson-test-server": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/traverson-test-server/-/traverson-test-server-1.11.0.tgz",
-      "integrity": "sha512-zX4tuyFh/k15b8iToBk7vmerEXOpeMsyCkGD0aal4huf70hGUM3QCDZgGpw0k7me//4m5+fgdXTeQVICxwh4/g==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/traverson-test-server/-/traverson-test-server-1.12.1.tgz",
+      "integrity": "sha512-DLBSjNf+Mqq+uoDyBRkcu3bKMalbN2SpeOVcyYGFYJOUYNbhBLs8Ox1eGI4RU3rQ+a5nR4CbzayTwSOGcLPOBA==",
       "dev": true,
       "requires": {
         "basic-auth-connect": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "sinon": "^6.1.3",
     "sinon-chai": "^3.2.0",
     "traverson-mock-response": "1.1.0",
-    "traverson-test-server": "1.11.0"
+    "traverson-test-server": "^1.12.1"
   },
   "browser": {
     "minilog": "./browser/lib/shim/log.js",

--- a/test/localhost.js
+++ b/test/localhost.js
@@ -217,7 +217,7 @@ describe('Traverson (when tested against a local server)', function() {
         var error = callback.firstCall.args[0];
         expect(error).to.exist;
         expect(error.name).to.equal(traverson.errors.HTTPError);
-        expect(error.message).to.equal('HTTP GET for ' + rootUri +
+        expect(error.message).to.equal('HTTP GET request to ' + rootUri +
             'does/not/exist' + ' resulted in HTTP status code 404.');
         expect(error.url).to.equal(rootUri + 'does/not/exist');
         expect(error.httpStatus).to.equal(404);
@@ -266,7 +266,7 @@ describe('Traverson (when tested against a local server)', function() {
         var error = callback.firstCall.args[0];
         expect(error).to.exist;
         expect(error.name).to.equal(traverson.errors.HTTPError);
-        expect(error.message).to.equal('HTTP GET for ' + rootUri +
+        expect(error.message).to.equal('HTTP GET request to ' + rootUri +
             'does/not/exist' + ' resulted in HTTP status code 404.');
         expect(error.url).to.equal(rootUri + 'does/not/exist');
         expect(error.httpStatus).to.equal(404);
@@ -377,7 +377,7 @@ describe('Traverson (when tested against a local server)', function() {
         var error = callback.firstCall.args[0];
         expect(error).to.exist;
         expect(error.name).to.equal(traverson.errors.HTTPError);
-        expect(error.message).to.equal('HTTP GET for ' + rootUri +
+        expect(error.message).to.equal('HTTP GET request to ' + rootUri +
             'does/not/exist' + ' resulted in HTTP status code 404.');
         expect(error.url).to.equal(rootUri + 'does/not/exist');
         expect(error.httpStatus).to.equal(404);
@@ -750,6 +750,38 @@ describe('Traverson (when tested against a local server)', function() {
         expect(xhr.withCredentials).to.exist;
         expect(xhr.withCredentials).to.equal(true);
         done();
+      }
+    );
+  });
+
+  it('should correctly state the HTTP verb with convertResponseObject',
+      function (done) {
+    var payload = {'new': 'document'};
+    api
+      .newRequest()
+      .withTemplateParameters({param: 'foobar', id: 13})
+      .follow('uri_template')
+      .withRequestOptions([ {}, { qs: { 'fail': true } } ])
+      .convertResponseToObject()
+      .post(payload, callback);
+    waitFor(
+      function() { return callback.called; },
+      function() {
+        expect(callback.callCount).to.equal(1);
+        var error = callback.firstCall.args[0];
+        expect(error).to.exist;
+        expect(error.name).to.equal(traverson.errors.HTTPError);
+        expect(error.message).to.equal('HTTP POST request to ' + rootUri +
+            'foobar/fixed/13 resulted in HTTP status code 400.');
+        expect(error.url).to.equal(rootUri + 'foobar/fixed/13');
+        expect(error.httpStatus).to.equal(400);
+
+        var lastBody = error.body;
+        expect(lastBody).to.exist;
+        expect(lastBody).to.contain('nope');
+        expect(lastBody).to.contain('nope');
+        done();
+
       }
     );
   });


### PR DESCRIPTION
In case the last request failed and convertResponseToObject() has been
used, the error message would always talk about a GET request, even when
it was actually a different HTTP method.

Fixes #97